### PR TITLE
bugfix OverlapData overuse of RAM when opening existing file

### DIFF
--- a/tests/unit/test_MergeData.py
+++ b/tests/unit/test_MergeData.py
@@ -15,8 +15,8 @@ import coloredlogs
 import numpy as np
 import pandas as pd
 
-from transposon.merge import MergeData
-from transposon.merge import _MergeConfigSink, _MergeConfigSource, _SummationArgs
+from transposon.merge_data import MergeData
+from transposon.merge_data import _MergeConfigSink, _MergeConfigSource, _SummationArgs
 from transposon.transposon_data import TransposonData
 from transposon.gene_data import GeneData
 from transposon.overlap import OverlapData, OverlapWorker

--- a/transposon/merge_worker.py
+++ b/transposon/merge_worker.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+"""
+Orchestrates the summation of many OverlapData into many MergeData.
+"""
+
+__author__ = "Michael Teresi"
+
+from collections import namedtuple
+import logging
+import os
+from functools import partial
+import pprint
+
+import h5py
+import numpy as np
+
+import transposon
+
+
+class MergeWorker():
+    """Orchestrates merging multiple OverlapData."""
+
+    def __init__(self, overlaps, transposons, genome, windows, output_dir, logger):
+        """Initialzer.
+
+        Args:
+            overlaps (iterable(str)): filepaths to OverlapData.
+            transposons (str): path to TransposonData file.
+            genes (str): path to GeneData file.
+            windows (iterable(int)): input window values.
+            output_dir (str): path to output results.
+        """
+
+        pass
+
+
+    def scrape_chromosome_ids(self):
+        pass
+
+
+    # scrape the windows from the overlap files, pass to MergeData
+    # scrape genes from the overlap files, pass to MergeData

--- a/transposon/overlap.py
+++ b/transposon/overlap.py
@@ -172,6 +172,7 @@ class OverlapData():
     def from_file(cls, filepath, logger=None):
         """Read only source for an existing file."""
 
+        # FUTURE specify ram usage in order to scrape components instead of reading all
         file_abs = os.path.abspath(filepath)
         if not os.path.isfile(file_abs):
             raise ValueError("input filepath not a file: %s" % file_abs)
@@ -203,7 +204,6 @@ class OverlapData():
         self._h5_file.flush()
         self._h5_file.close()
         self._h5_file = None
-        self._config = None
 
         self.left = None
         self.right = None
@@ -263,9 +263,9 @@ class OverlapData():
         self.gene_names = self._read_gene_names()
         self.windows = self._read_windows()
         self.chromosome_id = self._read_chromosome_id()
-        self.left = self._h5_file[self._LEFT][:]
-        self.intra = self._h5_file[self._INTRA][:]
-        self.right = self._h5_file[self._RIGHT][:]
+        self.left = self._h5_file[self._LEFT]
+        self.intra = self._h5_file[self._INTRA]
+        self.right = self._h5_file[self._RIGHT]
 
     def _open_new_file(self, cfg):
         """Initialize a new file for writing."""


### PR DESCRIPTION
- bugfix OverlapData, don't retrieve matrices on read, retrive names
    - file[key][:] changed to file[key]
    - OverlapData._open_existing_file now gets name to matrix, not value
- move merge.py --> merge_data.py
- add merge_worker.py stub
- address flake8 on overlap.py