### PR TITLE
refactor overlap output location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/*.swp
+**/*.swo
 **/*.orig
 **/*.pyc
 tags

--- a/config/test_run_config.ini
+++ b/config/test_run_config.ini
@@ -1,4 +1,4 @@
 [density_parameters]
-first_window_size = 100
-window_delta = 100
-last_window_size = 1000
+first_window_size = 400
+window_delta = 200
+last_window_size = 800

--- a/process_genome.py
+++ b/process_genome.py
@@ -86,14 +86,6 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--overlap_dir",
-        "-s",
-        type=str,
-        default=os.path.abspath("/tmp"),
-        help="directory for temporary overlap files",
-    )
-
-    parser.add_argument(
         "--reset_h5",
         action="store_true",
         help="Rewrite h5 intermediate files for gene & TEs",
@@ -181,11 +173,12 @@ if __name__ == "__main__":
     filepaths = list(preprocessor.data_filepaths())
     overlap_mgr = OverlapManager(
             filepaths,
-            "/media/data/genes/tmp/",
+            args.output_dir,
             alg_parameters["window_range"]
             )
     overlap_results = overlap_mgr.calculate_overlap()
     logger.info("processed %d overlap jobs" % len(overlap_results))
     logger.info("process overlap... complete")
 
+    
     raise NotImplementedError()

--- a/tests/unit/test_OverlapData.py
+++ b/tests/unit/test_OverlapData.py
@@ -40,12 +40,20 @@ def temp_dir():
     with tempfile.TemporaryDirectory() as temp_dir:
         yield temp_dir
 
+
+@pytest.yield_fixture
+def temp_file():
+    """Temporary directory."""
+
+    with tempfile.NamedTemporaryFile(suffix="."+OverlapData.EXT) as temp_file:
+        yield temp_file.name
+
 @pytest.fixture
-def default_data_out(temp_dir):
+def default_data_out(temp_file):
     """Return default output OverlapData instance."""
 
     return OverlapData.from_param(
-        GeneData.mock(), N_TRANSPOSONS, WINDOWS, temp_dir, logger=LOGGER
+        GeneData.mock(), N_TRANSPOSONS, WINDOWS, temp_file, logger=LOGGER
     )
 
 @pytest.yield_fixture
@@ -80,10 +88,10 @@ def serialized_deserialized(default_data_out):
         with OverlapData.from_file(filepath) as input:
             yield (input, output)
 
-def test_from_param_raise(gene_data, temp_dir):
+def test_from_param_raise(gene_data, temp_file):
     """Does the from param factory raise?"""
 
-    OverlapData.from_param(gene_data, N_TRANSPOSONS, WINDOWS, temp_dir, logger=LOGGER)
+    OverlapData.from_param(gene_data, N_TRANSPOSONS, WINDOWS, temp_file, logger=LOGGER)
 
 def test_from_param_raise_enter_exit(active_output):
     """Does the context manager raise for an output file?"""


### PR DESCRIPTION
specify file for overlap outputs instead of dir,
so we can keep track of the temporary files by name