### PR TITLE
D/matching chromosomes

### DIFF
--- a/process_genome.py
+++ b/process_genome.py
@@ -231,23 +231,10 @@ if __name__ == "__main__":
     if args.num_threads is not None:
         args.num_threads = int(args.num_threads)
 
-    filtered_input_data_loc = os.path.abspath(
-        os.path.join(args.output_dir, "filtered_input_data")
-    )
-    input_h5_cache_loc = os.path.abspath(
-        os.path.join(args.output_dir, filtered_input_data_loc, "input_h5_cache")
-    )
-
-    revised_input_data_loc = os.path.abspath(
-        os.path.join(args.output_dir, filtered_input_data_loc, "revised_input_data")
-    )
     tmp_overlap_loc = os.path.abspath(os.path.join(args.output_dir, "tmp", "overlap"))
 
     # NOTE make directories for intermediate and final output data
     os.makedirs(args.output_dir, exist_ok=True)
-    os.makedirs(filtered_input_data_loc, exist_ok=True)
-    os.makedirs(input_h5_cache_loc, exist_ok=True)
-    os.makedirs(revised_input_data_loc, exist_ok=True)
     os.makedirs(tmp_overlap_loc, exist_ok=True)
 
     log_level = logging.DEBUG if args.verbose else logging.INFO
@@ -266,16 +253,14 @@ if __name__ == "__main__":
     preprocessor = PreProcessor(
         args.genes_input_file,
         args.tes_input_file,
-        filtered_input_data_loc,
-        input_h5_cache_loc,
-        revised_input_data_loc,
+        args.output_dir,
         args.reset_h5,
         args.genome_id,
         args.revise_anno,
     )
     preprocessor.process()
     n_data_files = sum(1 for _ in preprocessor.data_filepaths())
-    rel_preproc = os.path.relpath(input_h5_cache_loc)
+    rel_preproc = os.path.relpath(preprocessor.h5_cache_dir)
     logger.info("preprocessed %d files to %s" % (n_data_files, rel_preproc))
     logger.info("preprocessing... complete")
 

--- a/tests/input_data/Test_Preprocess_Cleaned_Genes.tsv
+++ b/tests/input_data/Test_Preprocess_Cleaned_Genes.tsv
@@ -1,0 +1,15 @@
+Gene_Name	Chromosome	Feature	Start	Stop	Strand	Length
+maker-VaccDscaff1-snap-gene-0.31	VaccDscaff1	gene	893.0	24185.0	+	23293.0
+maker-VaccDscaff1-snap-gene-0.32	VaccDscaff1	gene	24880.0	31033.0	+	6154.0
+maker-VaccDscaff1-snap-gene-0.36	VaccDscaff1	gene	31517.0	32457.0	-	941.0
+maker-VaccDscaff1-snap-gene-0.37	VaccDscaff1	gene	32462.0	39522.0	-	7061.0
+snap_masked-VaccDscaff1-processed-gene-0.15	VaccDscaff1	gene	49288.0	54958.0	+	5671.0
+maker-VaccDscaff1-augustus-gene-0.27	VaccDscaff1	gene	62151.0	89671.0	+	27521.0
+maker-VaccDscaff1-augustus-gene-0.30	VaccDscaff1	gene	86018.0	89723.0	-	3706.0
+maker-VaccDscaff1-augustus-gene-1.27	VaccDscaff1	gene	97467.0	99179.0	-	1713.0
+augustus_masked-VaccDscaff1-processed-gene-1.5	VaccDscaff1	gene	107244.0	110895.0	-	3652.0
+maker-VaccDscaff1-snap-gene-1.29	VaccDscaff1	gene	110385.0	118861.0	+	8477.0
+maker-VaccDscaff1-augustus-gene-1.24	VaccDscaff1	gene	128901.0	132573.0	+	3673.0
+maker-VaccDscaff1-augustus-gene-1.25	VaccDscaff1	gene	147894.0	149490.0	+	1597.0
+maker-VaccDscaff1-snap-gene-1.32	VaccDscaff1	gene	179007.0	185476.0	+	6470.0
+maker-VaccDscaff1-augustus-gene-1.28	VaccDscaff1	gene	186127.0	189575.0	-	3449.0

--- a/tests/input_data/Test_Preprocess_Cleaned_TEs_Unequal_Chrom_IDs.tsv
+++ b/tests/input_data/Test_Preprocess_Cleaned_TEs_Unequal_Chrom_IDs.tsv
@@ -1,0 +1,15 @@
+Chromosome	Start	Stop	Strand	Order	SuperFamily	Length
+VaccDscaff24	280.0	369.0	+	LTR	Unknown_LTR_Superfam	90.0
+VaccDscaff24	396.0	494.0	-	TIR	Tc1-Mariner	99.0
+VaccDscaff24	495.0	783.0	+	TIR	Tc1-Mariner	289.0
+VaccDscaff24	3197.0	3361.0	+	TIR	hAT	165.0
+VaccDscaff24	3722.0	3847.0	+	LTR	Copia	126.0
+VaccDscaff24	3749.0	3981.0	-	TIR	Tc1-Mariner	233.0
+VaccDscaff24	4349.0	4509.0	-	Helitron	Helitron	161.0
+VaccDscaff24	4451.0	4663.0	+	Helitron	Helitron	213.0
+VaccDscaff24	4591.0	4681.0	+	TIR	Mutator	91.0
+VaccDscaff24	4884.0	5172.0	-	LTR	Unknown_LTR_Superfam	289.0
+VaccDscaff24	7111.0	7267.0	-	Helitron	Helitron	157.0
+VaccDscaff24	7174.0	7288.0	+	TIR	PIF-Harbinger	115.0
+VaccDscaff24	7209.0	7400.0	+	Helitron	Helitron	192.0
+VaccDscaff24	10667.0	10833.0	+	LTR	Copia	167.0

--- a/tests/input_data/Test_Preprocess_Cleaned_TEs_Unequal_Number_Chrom.tsv
+++ b/tests/input_data/Test_Preprocess_Cleaned_TEs_Unequal_Number_Chrom.tsv
@@ -1,0 +1,15 @@
+Chromosome	Start	Stop	Strand	Order	SuperFamily	Length
+VaccDscaff1	280.0	369.0	+	LTR	Unknown_LTR_Superfam	90.0
+VaccDscaff1	396.0	494.0	-	TIR	Tc1-Mariner	99.0
+VaccDscaff1	495.0	783.0	+	TIR	Tc1-Mariner	289.0
+VaccDscaff1	3197.0	3361.0	+	TIR	hAT	165.0
+VaccDscaff1	3722.0	3847.0	+	LTR	Copia	126.0
+VaccDscaff1	3749.0	3981.0	-	TIR	Tc1-Mariner	233.0
+VaccDscaff1	4349.0	4509.0	-	Helitron	Helitron	161.0
+VaccDscaff1	4451.0	4663.0	+	Helitron	Helitron	213.0
+VaccDscaff1	4591.0	4681.0	+	TIR	Mutator	91.0
+VaccDscaff2	4884.0	5172.0	-	LTR	Unknown_LTR_Superfam	289.0
+VaccDscaff2	7111.0	7267.0	-	Helitron	Helitron	157.0
+VaccDscaff2	7174.0	7288.0	+	TIR	PIF-Harbinger	115.0
+VaccDscaff2	7209.0	7400.0	+	Helitron	Helitron	192.0
+VaccDscaff2	10667.0	10833.0	+	LTR	Copia	167.0

--- a/tests/unit/test_preprocess.py
+++ b/tests/unit/test_preprocess.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+"""
+Test preprocess
+"""
+
+__author__ = "Scott Teresi"
+
+import pytest
+import tempfile
+import pandas as pd
+
+from transposon.gene_data import GeneData
+from transposon.transposon_data import TransposonData
+from transposon.preprocess import PreProcessor
+
+
+@pytest.fixture
+def gene_file(request):
+    """path to simple gene annotation file for testing."""
+    return request.param
+
+
+@pytest.fixture
+def transposon_file(request):
+    """
+    path to simple TE annotation file for testing. This file is special in
+    that it does not have corresponding chromosome IDs to the gene file.
+    """
+    return request.param
+
+
+@pytest.yield_fixture()
+def temp_dir():
+    """Temporary directory."""
+
+    with tempfile.TemporaryDirectory() as dir:
+        yield dir
+
+
+@pytest.mark.parametrize(
+    "gene_file",
+    [
+        "tests/input_data/Test_Preprocess_Cleaned_Genes.tsv",
+    ],
+)
+@pytest.mark.parametrize(
+    "transposon_file",
+    [
+        "tests/input_data/Test_Preprocess_Cleaned_TEs_Unequal_Chrom_IDs.tsv",
+        "tests/input_data/Test_Preprocess_Cleaned_TEs_Unequal_Number_Chrom.tsv",
+    ],
+)
+def test_validate_split(gene_file, transposon_file, temp_dir):
+    """
+    Does the program fail elegantly when you give it BAD input annotations that
+    do not have the right corresponding chromosomes?
+
+    Args:
+        gene_file (str): string to filepath of a "cleaned" gene annotation
+        transposon_file (str): string to filepath of a "cleaned" TE annotation
+        temp_dir (str): string to filepath for temporary output dir
+    """
+    preprocessor_obj = PreProcessor(
+        gene_file,
+        transposon_file,
+        temp_dir,
+        False,  # reset h5 arg
+        "fake_genome_id",  # MAGIC genome ID arg
+        True,  # revise TE arg
+    )
+    gene_frame = preprocessor_obj._filter_genes()
+    transposon_frame = preprocessor_obj._filter_transposons()
+    transposon_frame = preprocessor_obj._revise_transposons(transposon_frame)
+    with pytest.raises(ValueError) as exc:
+        preprocessor_obj._split_wrt_chromosome(gene_frame, transposon_frame)
+
+
+if __name__ == "__main__":
+    pytest.main(["-s", __file__])

--- a/transposon/gene_data.py
+++ b/transposon/gene_data.py
@@ -71,6 +71,36 @@ class GeneData(object):
         frame.set_index("Gene_Name", inplace=True)
         return GeneData(frame, genome_id)
 
+    @classmethod
+    def mock_v2(
+        cls,
+        start_stop=np.array([[500, 1000], [800, 1500], [1600, 2000]]),
+        chromosome_ids=["Chrom_1", "Chrom_2", "Chrom_3"],
+        genome_id="fake_genome_id",
+    ):
+        """Mocked data for testing. TODO refactor with main mock.
+
+        Args:
+            start_stop (numpy.array): N gene x (start_idx, stop_idx)
+            chromosome_id (list): List of string, len(N gene)
+        """
+
+        n_genes = start_stop.shape[0]
+        data = []
+        for gi in range(n_genes):
+            g0 = start_stop[gi, 0]
+            g1 = start_stop[gi, 1]
+            gL = g1 - g0 + 1
+            name = "gene_{}".format(gi)
+            chromosome_id = chromosome_ids[gi]
+            datum = [name, g0, g1, gL, chromosome_id]
+            data.append(datum)
+
+        col_names = ["Gene_Name", "Start", "Stop", "Length", "Chromosome"]
+        frame = pd.DataFrame(data, columns=col_names)
+        frame.set_index("Gene_Name", inplace=True)
+        return GeneData(frame, genome_id)
+
     def write(self, filename, key="default"):
         """Write a Pandaframe to disk.
 

--- a/transposon/preprocess.py
+++ b/transposon/preprocess.py
@@ -40,12 +40,6 @@ class PreProcessor:
     EXT = "tsv"
     CACHE_EXT = "h5"
 
-    # TODO SCOTT pls reduce number of input args by:
-    # replacing [filtered_dir, h5_cache_dir, revised_dir], with one directory
-    # (e.g. 'results_dir'), then create the sub directories there
-    # there doesn't need to be invididual inputs for each one
-    # then those sub directories can just be properties on this
-
     def __init__(
         self,
         gene_file,

--- a/transposon/transposon_data.py
+++ b/transposon/transposon_data.py
@@ -78,6 +78,37 @@ class TransposonData(object):
         frame = pd.DataFrame(data, columns=columns)
         return TransposonData(frame, genome_id)
 
+    @classmethod
+    def mock_v2(
+        cls,
+        start_stop=np.array([[0, 9], [10, 19], [20, 29]]),
+        order_ids=["LTR", "TIR", "LINE"],
+        superfamily_ids=["Gypsy", "Mutator", "L1"],
+        chromosome_ids=["Chrom_1", "Chrom_2", "Chrom_3"],
+        genome_id="fake_genome_id",
+    ):
+        """Mocked data for testing. TODO refactor with main mock.
+
+        Args:
+            start_stop (numpy.array): N gene x (start_idx, stop_idx)
+        """
+        # TODO check to make sure all the arrays are same length
+
+        n_tes = start_stop.shape[0]
+        data = []
+        columns = ["Start", "Stop", "Length", "Order", "SuperFamily", "Chromosome"]
+        for ti in range(n_tes):
+            g0 = start_stop[ti, 0]
+            g1 = start_stop[ti, 1]
+            gL = g1 - g0 + 1
+            chromosome_id = chromosome_ids[ti]
+            order_id = order_ids[ti]
+            superfamily_id = superfamily_ids[ti]
+            datum = [g0, g1, gL, order_id, superfamily_id, chromosome_id]
+            data.append(datum)
+        frame = pd.DataFrame(data, columns=columns)
+        return TransposonData(frame, genome_id)
+
     def write(self, filename, key="default"):
         """Write a Pandaframe to disk.
 
@@ -186,8 +217,10 @@ class TransposonData(object):
         # TODO verify that this isn't weird
         length = self.lengths.shape
         if start != length:
-            msg = "Input TE missing fields: starts.shape {}  != lengths.shape {}".format(
-                start, stop
+            msg = (
+                "Input TE missing fields: starts.shape {}  != lengths.shape {}".format(
+                    start, stop
+                )
             )
             self._logger.critical(msg)
             raise ValueError(msg)


### PR DESCRIPTION
- Add better log and error messages to the pipeline for the (likely common) error when users provide annotation files that do not have corresponding chromosomes. I.e a gene annotation with 7 chromosomes and a TE annotation with 8 chromosomes. OR the situation where they have the same total number of chromosomes but the IDs are different.
- Refactor preprocess() to have less input args under the hood.
- Also add a better (but half-finished) mock data structure for TransposonData and GeneData