### PR TITLE
F/manager context

### DIFF
--- a/config/test_run_config.ini
+++ b/config/test_run_config.ini
@@ -1,4 +1,4 @@
 [density_parameters]
 first_window_size = 400
 window_delta = 200
-last_window_size = 800
+last_window_size = 400

--- a/process_genome.py
+++ b/process_genome.py
@@ -170,7 +170,7 @@ class MergeProgress:
 def result_to_job(result, windows, output_dir, pbar_callback):
     """Convert an overlap result to a merge job."""
 
-    job = MergeJob(
+    _job = MergeJob(
         str(result.overlap_file),
         str(result.te_file),
         str(result.gene_file),
@@ -178,7 +178,7 @@ def result_to_job(result, windows, output_dir, pbar_callback):
         str(output_dir),
         pbar_callback,
     )
-    return job
+    return _job
 
 
 if __name__ == "__main__":

--- a/process_genome.py
+++ b/process_genome.py
@@ -69,7 +69,7 @@ from queue import Empty
 
 MergeJob = namedtuple(
     "MergeJob",
-    ["overlap_file", "te_file", "gene_file", "windows", "output_dir", "progress_bar"],
+    ["overlap_file", "te_file", "gene_file", "windows", "output_dir", "progress_bar_callback"],
 )
 
 
@@ -101,19 +101,29 @@ def calc_merge_number_operations(job):
 
 
 def calc_merge(job):
-    """Target for a process to calculate density given a job."""
+    """Target for a process to calculate density given a job.
+
+    Args:
+        job(MergeJob): container of density parameters and etc. for a pseudo-molecule.
+    """
 
     merge_data, overlap_data = job_2_merge_and_overlap(job)
     gene_data = GeneData.read(job.gene_file)
     with merge_data as merge_output:
         with overlap_data as overlap_input:
-            merge_output.sum(overlap_input, gene_data, job.progress_bar)
+            merge_output.sum(overlap_input, gene_data, job.progress_bar_callback)
 
 
 class MergeProgress:
     """Show progress of the merge."""
 
     def __init__(self, queue, progress):
+        """Initialize.
+
+        Args:
+            queue(Queue): multiprocessing queue for results
+            progress(tqdm) progress bar
+        """
 
         self.stop_event = Event()
         self.queue = queue
@@ -121,30 +131,45 @@ class MergeProgress:
         self._thread = None
 
     def __enter__(self):
+        """Context manager start."""
 
         self.stop_event.clear()
         if self._thread is not None:
             self._thread.join()
-        self._thread = Thread(target=self.exec)
+        self._thread = Thread(target=self._exec)
         self._thread.start()
         return self
 
     def __exit__(self, type, val, trace):
+        """Context manager stop."""
 
         self.stop_event.set()
 
-    def exec(self):
+    def _exec(self):
+        """Loop to listen for progress bar updates."""
+
         while not self.stop_event.is_set():
             try:
-                result = self.queue.get(timeout=0.2)
+                # MAGIC arbitrary, mainly effects time to kill this
+                result = self.queue.get(timeout=1.0)
             except Empty:
                 continue
+            else:
+                self.queue.task_done()
 
-            self.progress.update()
+            if result is None:  # MAGIC None is our sentinel
+                self.stop_event.set()
+            else:
+                self.progress.update()
+                self.progress.refresh()
+
+        self.progress.refresh()
+        self.progress.close()
 
 
 def result_to_job(result, windows, output_dir, pbar_callback):
     """Convert an overlap result to a merge job."""
+
     job = MergeJob(
         str(result.overlap_file),
         str(result.te_file),
@@ -277,9 +302,11 @@ if __name__ == "__main__":
     logger.info("process density")
 
     win = alg_parameters["window_range"]
-    pbar_update_mgr = Manager()
-    pbar_update_queue = pbar_update_mgr.Queue()
-    pbar_update = partial(pbar_update_queue.put_nowait, None)
+    multiproc_mgr = Manager()
+    # MAGIC arbitrary, consumer queue is very fast compared to producer
+    pbar_update_queue = multiproc_mgr.Queue(maxsize=512)
+    # MAGIC arbitrary for a single result, using None as sentinel
+    pbar_update = partial(pbar_update_queue.put_nowait, 1)
     jobs = [
         result_to_job(res, win, args.output_dir, pbar_update) for res in overlap_results
     ]
@@ -290,23 +317,28 @@ if __name__ == "__main__":
         position=0,
         ncols=80,
     )
-    with MergeProgress(pbar_update_queue, pbar_subsets) as my_progress:
-        if not args.single_process:
-            with Pool(processes=args.num_threads) as my_pool:
-                my_pool.map(calc_merge, jobs)
-        else:
-            for job in jobs:
-                try:
-                    pr = cProfile.Profile()
-                    pr.enable()
-                    calc_merge(job)
-                except KeyboardInterrupt as keybr:
-                    pr.disable()
-                    stream = io.StringIO()
-                    sortby = "cumulative"
-                    ps = pstats.Stats(pr, stream=stream).sort_stats(sortby)
-                    ps.print_stats(0.1)  # MAGIC percent to print
-                    print(stream.getvalue())
-                    raise keybr
+    with multiproc_mgr as my_multiproc_mgr:
+        with MergeProgress(pbar_update_queue, pbar_subsets) as my_progress:
+            if not args.single_process:
+                with Pool(processes=args.num_threads) as my_pool:
+                    my_pool.map(calc_merge, jobs)
+                # NB signal to progress bar the jobs are done in attempt to debug EOFError
+                pbar_update_queue.put_nowait(None)  # MAGIC using None as a sentinel
+            else:  #
+                logger.info("running in single process mode for profiling,")
+                logger.info("  recommended for debugging only...")
+                for job in jobs:
+                    try:
+                        pr = cProfile.Profile()
+                        pr.enable()
+                        calc_merge(job)
+                    except KeyboardInterrupt as keybr:
+                        pr.disable()
+                        stream = io.StringIO()
+                        sortby = "cumulative"
+                        ps = pstats.Stats(pr, stream=stream).sort_stats(sortby)
+                        ps.print_stats(0.1)  # MAGIC percent to print
+                        print(stream.getvalue())
+                        raise keybr
 
     logger.info("process density... complete")

--- a/transposon/import_filtered_TEs.py
+++ b/transposon/import_filtered_TEs.py
@@ -30,21 +30,18 @@ def import_filtered_TEs(tes_input_path, logger):
                 "SuperFamily": str,
             },
         )
-    except:
-        raise ValueError(
-            """Error occurred while trying to read preprocessed TE
-                         annotation file into a Pandas dataframe, please refer
-                         to the README as to what information is expected"""
-        )
+    except Exception as err:
+        msg = ("Error occurred while trying to read preprocessed TE "
+               "annotation file into a Pandas dataframe, please refer "
+               "to the README as to what information is expected")
+        logger.critical(msg)
+        raise err
+
     check_nulls(transposon_data, logger)
 
     # Sort for legibility
     transposon_data.sort_values(by=["Chromosome", "Start"], inplace=True)
 
-    logger.info(
-        """Successfully imported the preprocessed transposon annotation
-        information: %s """
-        % tes_input_path
-    )
+    logger.info("import of pre-filtered transposon annotation... success!")
 
     return transposon_data

--- a/transposon/import_filtered_genes.py
+++ b/transposon/import_filtered_genes.py
@@ -29,14 +29,13 @@ def import_filtered_genes(genes_input_path, logger):
                 "Feature": str,
             },
         )
-    except:
-        raise ValueError(
-            """
-            Error occurred while trying to read preprocessed gene
-            annotation file into a Pandas dataframe, please refer
-            to the README as to what information is expected
-            """
-        )
+    except Exception as err:
+        msg = ("Error occurred while trying to read preprocessed gene "
+               "annotation file into a Pandas dataframe, please refer "
+               "to the README as to what information is expected ")
+        logger.critical(msg)
+        raise err
+
     check_nulls(gene_data, logger)
     check_strand(gene_data, logger)
 
@@ -47,9 +46,5 @@ def import_filtered_genes(genes_input_path, logger):
     # Sort for legibility
     gene_data.sort_values(by=["Chromosome", "Start"], inplace=True)
 
-    logger.info(
-        """Successfully imported the preprocessed gene annotation
-        information: %s """
-        % genes_input_path
-    )
+    logger.info("import of preprocessed gene annotation... success!")
     return gene_data

--- a/transposon/merge_data.py
+++ b/transposon/merge_data.py
@@ -355,14 +355,14 @@ class MergeData:
 
         return len(self._list_density_args(overlap))
 
-    def sum(self, overlap, gene_data, progress_bar=None):
+    def sum(self, overlap, gene_data, progress_bar_cb=None):
         """Sum across the superfamily / order dimension.
 
         Args:
             overlap(OverlapData): container for the intermediate overlap values
             gene_data (GeneData): container for the gene data for one
             pseudomolecule
-            progress_bar(?):
+            progress_bar_cb(callable): callback after each sub calculation
         """
 
         self._validate_chromosome(overlap)
@@ -377,8 +377,8 @@ class MergeData:
         random.shuffle(sums_)  # make progress bar update more evenly
         for args in sums_:
             self._process_sum(overlap, gene_data, args)
-            if progress_bar is not None:
-                progress_bar()
+            if progress_bar_cb is not None:
+                progress_bar_cb()
 
     def _process_sum(self, overlap, gene_data, sum_args):
         """Calculate the sum for one (left | intra | right) & (superfamily | order).
@@ -387,7 +387,6 @@ class MergeData:
             overlap (OverlapData): input data
             gene_data (GeneData): chromosome conatiner
             sum_args (_SummationArgs): parameters for calculations
-            progress (callable): command to update progress
         """
 
         # N.B. loop order affects speed wrt order in data set (SEE self._create_sets)
@@ -435,7 +434,13 @@ class MergeData:
                     sum_args.output[slice_out] = np.divide(overlap_sum, divisor)
 
     def _list_density_args(self, overlap):
-        """List all arguments for calculating the densities."""
+        """List all arguments for calculating the densities.
+
+        Args:
+            overlap(OverlapData): input overlap container
+        Returns:
+            iterable(_SummationArgs): arguments for calculating the sums
+        """
 
         superfam = self._list_sum_input_outputs(
             overlap,
@@ -459,7 +464,7 @@ class MergeData:
     def _list_sum_input_outputs(
         cls, overlap, density, te_group, te_set, te_idx_map, windows
     ):
-        """
+        """List of parameters for each computation.
 
         Args:
             overlap(OverlapData): input overlap container
@@ -469,7 +474,7 @@ class MergeData:
             windows(list(int)): window sizes
 
         Returns:
-            iterable(_SummationArgs): arguments for calculating the sums.
+            iterable(_SummationArgs): arguments for calculating the sums
         """
 
         # NOTE this could be (very) improved, but for now let's get a first iteration...

--- a/transposon/preprocess.py
+++ b/transposon/preprocess.py
@@ -41,14 +41,14 @@ class PreProcessor:
     CACHE_EXT = "h5"
 
     def __init__(
-        self,
-        gene_file,
-        transposon_file,
-        results_dir,
-        reset_h5,
-        genome_id,
-        revise_transposons,
-        logger=None,
+            self,
+            gene_file,
+            transposon_file,
+            results_dir,
+            reset_h5,
+            genome_id,
+            revise_transposons,
+            logger=None,
     ):
         """Initialize.
 

--- a/transposon/verify_cache.py
+++ b/transposon/verify_cache.py
@@ -15,16 +15,16 @@ from transposon.import_filtered_TEs import import_filtered_TEs
 
 
 def verify_chromosome_h5_cache(
-    gene_data_obj,
-    te_data_obj,
-    h5_g_filename,
-    h5_t_filename,
-    reset_h5,
-    h5_cache_location,
-    genes_input_file,
-    tes_input_file,
-    chrom_id,
-    logger,
+        gene_data_obj,
+        te_data_obj,
+        h5_g_filename,
+        h5_t_filename,
+        reset_h5,
+        h5_cache_location,
+        genes_input_file,
+        tes_input_file,
+        chrom_id,
+        logger,
 ):
     """Determine whether or not previously saved gene_data and TransposonData
     exist in H5 format. Each h5 file represents either gene_data or
@@ -104,7 +104,7 @@ def verify_TE_cache(tes_input_file, logger):
     Returns:
         te_data (pandas.DataFrame): A pandas dataframe of the TE data
     """
-    logger.info("Reading pre-filtered TE annotation file %s" % tes_input_file)
+    logger.info("Reading pre-filtered TE annotation file: %s" % tes_input_file)
     te_data = import_filtered_TEs(tes_input_file, logger)
     return te_data
 
@@ -120,7 +120,7 @@ def verify_gene_cache(genes_input_file, logger):
     Returns:
         gene_data (pandas.DataFrame): the gene data container
     """
-    logger.info("Reading pre-filtered gene annotation file %s" % genes_input_file)
+    logger.info("Reading pre-filtered gene annotation file: %s" % genes_input_file)
     gene_data = import_filtered_genes(genes_input_file, logger)
     return gene_data
 


### PR DESCRIPTION
the first commit has an added context manager to the multiprocess manager
in an attempt to apply best practices for that just in case it interacts w/ those out of memory errors

the second commit is formatting (update docs, logs, indentation)

I do have some untracked files that I wasn't sure were supposed to be committed though:
	tests/input_data/test_swap_file.h5
	tests/input_data/test_swap_file_SenseSwapped.HDF5

#### testing
```
$ make test  # 195 passed, 2 skipped
```
```
$ ./process_genome.py ..//TE_Density_Filtered_Gene_and_TE_Annotations/Cleaned_TAIR10_GFF3_genes_main_chromosomes.tsv ../TE_Density_Filtered_Gene_and_TE_Annotations/Cleaned_TAIR10_chr_main_chromosomes.fas.mod.EDTA.TEanno.tsv adiposetoperus -n 2 --output_dir ../TE_Density_Filtered_Gene_and_TE_Annotations/results
...
subsets: 100%|██████████████████████████████████| 30/30 [10:24<00:00, 20.80s/it]
```