### PR TITLE
Fix method to correctly address edge case of missing data.

### DIFF
--- a/transposon/import_filtered_genes.py
+++ b/transposon/import_filtered_genes.py
@@ -30,9 +30,11 @@ def import_filtered_genes(genes_input_path, logger):
             },
         )
     except Exception as err:
-        msg = ("Error occurred while trying to read preprocessed gene "
-               "annotation file into a Pandas dataframe, please refer "
-               "to the README as to what information is expected ")
+        msg = """
+            Error occurred while trying to read preprocessed gene
+            annotation file into a Pandas dataframe, please refer
+            to the README as to what information is expected
+            """
         logger.critical(msg)
         raise err
 
@@ -41,7 +43,7 @@ def import_filtered_genes(genes_input_path, logger):
 
     # NOTE edit Strand '.' values to be sense orientation as
     # described in check_strand()
-    gene_data.loc[gene_data["Strand"] == "."] = "+"
+    gene_data["Strand"].replace(to_replace={".": "+"}, inplace=True)
 
     # Sort for legibility
     gene_data.sort_values(by=["Chromosome", "Start"], inplace=True)


### PR DESCRIPTION
Previously tried to address edge case where if a user provided a gene annotation that did NOT have sense or antisense strand information in their gene annotation (i.e the value of `'.'`) the program would autoformat those to sense strand (i.e `'+'`). This is described more in the documentation.

I was addressing this edge case wrong and was making that entire row have the value of `'+'`. This commit fixes that and does what I originally intended to do.