### PR TITLE
Add helper information so that user's can see what pseudomolecules and TE groups they have

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,4 +51,6 @@ tags:               ## run ctags
 	ctags \
 		$(ROOT_DIR)/*.py \
 		$(ROOT_DIR)/transposon/*.py
-
+system_test:
+	mkdir -p ./tmp
+	python $(ROOT_DIR)/process_genome.py $(ROOT_DIR)/tests/system_test_input_data/Cleaned_TAIR10_GFF3_genes_main_chromosomes.tsv $(ROOT_DIR)/tests/system_test_input_data/Cleaned_TAIR10_chr_main_chromosomes.fas.mod.EDTA.TEanno.tsv Arabidopsis -o ./tmp --revise_anno

--- a/transposon/import_filtered_TEs.py
+++ b/transposon/import_filtered_TEs.py
@@ -31,13 +31,19 @@ def import_filtered_TEs(tes_input_path, logger):
             },
         )
     except Exception as err:
-        msg = ("Error occurred while trying to read preprocessed TE "
-               "annotation file into a Pandas dataframe, please refer "
-               "to the README as to what information is expected")
+        msg = (
+            "Error occurred while trying to read preprocessed TE "
+            "annotation file into a Pandas dataframe, please refer "
+            "to the README as to what information is expected"
+        )
         logger.critical(msg)
         raise err
 
+    # Check for missing data issues
     check_nulls(transposon_data, logger)
+
+    # Report out to user some quick data metrics
+    logger.info(diagnostic_cleaner_helper(transposon_data))
 
     # Sort for legibility
     transposon_data.sort_values(by=["Chromosome", "Start"], inplace=True)
@@ -45,3 +51,20 @@ def import_filtered_TEs(tes_input_path, logger):
     logger.info("import of pre-filtered transposon annotation... success!")
 
     return transposon_data
+
+
+def diagnostic_cleaner_helper(TE_Data):
+    info = f"""
+    ---------------------------------
+    Filtered TE Annotation Information:
+    No. unique chromosomes: {len(TE_Data.Chromosome.unique())}
+    Unique chromosomes: {TE_Data.Chromosome.unique()}
+
+    No. unique TE Orders: {len(TE_Data.Order.unique())}
+    Unique TE Orders: {TE_Data.Order.unique()}
+
+    No. unique TE superfamilies: {len(TE_Data.SuperFamily.unique())}
+    Unique TE superfamilies: {TE_Data.SuperFamily.unique()}
+    ---------------------------------
+    """
+    return info

--- a/transposon/preprocess.py
+++ b/transposon/preprocess.py
@@ -228,15 +228,17 @@ class PreProcessor:
             genome_id (str) a string of the genome name.
         """
         # MAGIC get chromosome ID for each data frame
-        chromosomes_in_gene_set = [
-            gene_frame["Chromosome"].unique()[0] for gene_frame in gene_frames
-        ]
-        chromosomes_in_TE_set = [
-            te_frame["Chromosome"].unique()[0] for te_frame in te_frames
-        ]
+        chromosomes_in_gene_set = sorted(
+            [gene_frame["Chromosome"].unique()[0] for gene_frame in gene_frames]
+        )
+        chromosomes_in_TE_set = sorted(
+            [te_frame["Chromosome"].unique()[0] for te_frame in te_frames]
+        )
+        gene_minus_te = list(set(chromosomes_in_gene_set) - set(chromosomes_in_TE_set))
+        te_minus_gene = list(set(chromosomes_in_TE_set) - set(chromosomes_in_gene_set))
         if len(gene_frames) != len(te_frames):
             self._logger.critical(
-                """
+                f"""
                 Number of gene annotations split by chromosome != number of TE
                 annotations split by chromosome.
                 This error has arisen because you have some
@@ -248,10 +250,12 @@ class PreProcessor:
                 Please trim your annotations so that they have the same number and
                 set of chromosome IDs.
 
-                Unique chromosomes in cleaned gene annotation: %s
-                Unique chromosomes in cleaned TE annotation: %s
+                Chromosomes in cleaned gene annotation: {chromosomes_in_gene_set}
+                Chromosomes in cleaned TE annotation: {chromosomes_in_TE_set}
+                Intersection of both: {sorted(list(set(chromosomes_in_gene_set) & set(chromosomes_in_TE_set)))}
+                In gene but not in TE: {gene_minus_te}
+                In TE but not in gene: {te_minus_gene}
                 """
-                % (chromosomes_in_gene_set, chromosomes_in_TE_set)
             )
             raise ValueError
 


### PR DESCRIPTION
Just added some simple code to the import filtered TEs step. Outputs information to `logger.info` so that user's can see how many TE types they have and how many chromosomes they have. Should help with identifying if they have redundant groups, which seems to be a common user issue.