### PR TITLE
add error message for revision

### DIFF
--- a/transposon/revise_annotation.py
+++ b/transposon/revise_annotation.py
@@ -60,12 +60,19 @@ class ReviseAnno:
             self.whole_te_annotation which represents the amalgamation of the order,
             superfamily, and nameless revisions.
         """
+
+        self.logger = logging.getLogger(self.__class__.__name__)
         # Set stack size to unlimited so that we can use the code's recursion
         # for merging TEs.
-        resource.setrlimit(resource.RLIMIT_STACK, (resource.RLIM_INFINITY, -1))
+        try:
+            resource.setrlimit(resource.RLIMIT_STACK, (resource.RLIM_INFINITY, -1))
+        except ValueError as verr:
+            msg = ("could not raise recursion limit using 'resource' module, "
+                   "are you using Windows? revision may fail")
+            self.logger.error(msg)
+            self.logger.warn("got this ValueError in __init__: %s", str(verr))
 
         self.transposon_data = transposon_anno
-        self.logger = logging.getLogger(self.__class__.__name__)
         self.revised_superfam_file = os.path.abspath(
             os.path.join(output_dir, (genome_name + "_superfam_revision_cache.tsv"))
         )


### PR DESCRIPTION
- add error message for setting recursion limit on revision, to mitigate issue where some users may not have permissions to change their stack size / recursion limit

## DISCUSSION

one of the users got this error on `make system_test`
```
File "/Users/immlerlab/Documents/TE/TE_Density/transposon/revise_annotation.py", line 65, in init
resource.setrlimit(resource.RLIMIT_STACK, (1000, -1))
ValueError: not allowed to raise maximum limit
make: *** [system_test] Error 1
```

I can't reproduce but this change logs the error and attempts to continue

It could still fail later when it attempts the revision but I figure it's worth a shot


## TESTING

you can add a ValueError in the try block to see the log, so far I'm not sure how to reproduce,
but this will exercise the update

```
make system_clean
make system_test
...
2023-06-11 23:52:26 GOKU ReviseAnno[110652] ERROR could not raise recursion limit using 'resource' module, are you using Windows? revision may fail
2023-06-11 23:52:26 GOKU ReviseAnno[110652] WARNING got this ValueError in __init__: testing
...
```