### PR TITLE
Add check for non-unique genes, which causes overlap broadcast error

### DIFF
--- a/transposon/import_filtered_genes.py
+++ b/transposon/import_filtered_genes.py
@@ -19,7 +19,6 @@ def import_filtered_genes(genes_input_path, logger):
             genes_input_path,
             header="infer",
             sep="\t",
-            index_col="Gene_Name",
             dtype={
                 "Start": "float64",
                 "Stop": "float64",
@@ -27,6 +26,7 @@ def import_filtered_genes(genes_input_path, logger):
                 "Chromosome": str,
                 "Strand": str,
                 "Feature": str,
+                "Gene_Name": str,
             },
         )
     except Exception as err:
@@ -39,6 +39,7 @@ def import_filtered_genes(genes_input_path, logger):
         logger.critical(msg, genes_input_path)
         raise err
 
+    gene_data.set_index("Gene_Name", verify_integrity=True, inplace=True)
     check_nulls(gene_data, logger)
     check_strand(gene_data, logger)
 


### PR DESCRIPTION
Addresses #124 

# Problem:
Users would experience a cryptic error during the overlap calculation stage. Error would say that operands could not be broadcast together due to incorrect shape. This error would show up if users did not properly quality-control their data and duplicate gene names were present. Duplicate gene names would cause instances of `GeneDatum` to have more than 1 start or stop value. Having more than 1 start or stop value would break the overlap calculation function.

# Fix:
Add a check to the reading of preprocessed data. This check is at the pandas dataframe stage, before things are wrapped as `GeneData` or `GeneDatum`. The check raises an error if an index (a gene name) is non-unique.